### PR TITLE
feat : timzone Aisa/Seoul 고정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,13 @@ FROM python:3.12-slim
 # 2. 작업 디렉토리 설정
 WORKDIR /app
 
+# 시간대 환경 변수 설정
+ENV TZ=Asia/Seoul
+
+# 시간대 정보 설치 및 패키지 업데이트
+RUN apt-get update && apt-get install -y tzdata && \
+    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 # 3. 필요 파일 복사
 COPY requirements.txt ./
 

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import os
+import time
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -8,8 +9,20 @@ import uvicorn
 from config import refresh_connection_pool
 from controller import prompt_controller, event_controller
 
+# 시간대 Aisa/Seoul로 고정
+os.environ['TZ'] = 'Asia/Seoul'
+time.tzset()
+
+# DB Connection pool 관리 스케쥴러
 @asynccontextmanager
 async def lifespan(app : FastAPI):
+    """
+    DB connection pool을 관리하는 스케쥴러
+    
+    900초마다 지속적으로 커넥션 핑퐁을 통해 커넥션 유지
+    
+    셧다운 시 안전하게 커넥션 해제
+    """
     scheduler = BackgroundScheduler()
     scheduler.add_job(refresh_connection_pool, trigger='interval', seconds=900)
     scheduler.start()


### PR DESCRIPTION
## What

시간대가 UTC 기준으로, 대한민국 시간대보다 9시간 느리던 문제

## Result

Dockerfile 및 FastAPI 서버 내에서 Timezone을 Aisa/Seoul로 고정